### PR TITLE
feat: add BurgerButton component

### DIFF
--- a/src/components/layout/Header/burger-button.tsx
+++ b/src/components/layout/Header/burger-button.tsx
@@ -1,0 +1,24 @@
+'use client';
+import { useState } from 'react';
+
+export function BurgerButton() {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <button
+      onClick={() => setIsOpen(!isOpen)}
+      className="flex h-5 w-7 cursor-pointer flex-col items-center justify-center gap-1 md:h-7 md:w-12 md:gap-1.5"
+      aria-label="Toggle menu"
+    >
+      <span
+        className={`bg-accent block h-[0.2rem] w-6 origin-center rounded-3xl transition-all duration-300 md:h-[0.3rem] md:w-12 ${isOpen ? 'translate-y-1.75 rotate-45 md:translate-y-2.75' : ''}`}
+      />
+      <span
+        className={`bg-accent block h-[0.2rem] w-6 rounded-3xl transition-all duration-300 md:h-[0.3rem] md:w-12 ${isOpen ? 'scale-x-0 opacity-0' : ''}`}
+      />
+      <span
+        className={`bg-accent block h-[0.2rem] w-6 origin-center rounded-3xl transition-all duration-300 md:h-[0.3rem] md:w-12 ${isOpen ? '-translate-y-1.75 -rotate-45 md:-translate-y-2.75' : ''}`}
+      />
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary

Created a easy to use BurgerButton component that resizes depending on screen size and animates from an open state to a closed state when clicked. A refactor of the app needs to be done for a future clickOutside trigger. 

## Related Issue

Closes #75 

## Changes

- Created a BurgerButton component conforming to the Figma file
- Added an isOpen state to switch between the two versions of the component

## How to Test

1. git checkout feat/75-burger-button
2. Import the button into the home page and place it in the header
3. Check functionality on both mobile and desktop. 

## Checklist

- [ ] Code builds and runs locally
- [ ] Feature / fix works as expected
- [ ] No unintended changes
