### PR TITLE
feat: add cart icon

### DIFF
--- a/src/components/layout/Header/cart-icon.tsx
+++ b/src/components/layout/Header/cart-icon.tsx
@@ -12,7 +12,7 @@ export default function CartIcon({
   return (
     <div className={`relative ${className}`}>
       {!!itemsCount && (
-        <div className="bg-accent text-primary font-heading absolute -top-2.5 -right-1.5 flex h-3.5 w-3.5 items-center justify-center rounded-full text-xs md:h-4 md:w-4 lg:h-5 lg:w-5 lg:text-xl">
+        <div className="bg-accent text-primary font-heading absolute -top-2.5 -right-1.5 flex h-3.5 w-3.5 items-center justify-center rounded-full text-xs md:h-4 md:w-4 lg:h-5 lg:w-5 lg:text-base">
           <span className="-translate-y-px lg:-translate-y-0.5">{itemsCount}</span>
         </div>
       )}


### PR DESCRIPTION
## Summary

Created a cart icon that takes a itemsCount prop to display it. If no icon is given or if 0, the items count does not show up. 
## Related Issue

Closes #77 

## Changes

- Created cart item component for header
- Cart component can handle itemCount
- Cart component is responsive and handles an itemCount larger than 0

## How to Test

1. git checkout feat/77-cart-icon
2. npm run dev
3. import CartIcon from @/components/features/layout/Header/cart-icon into page.tsx
4. Test responsiveness and add a prop as itemsCount { 30 }
## Checklist

- [x] Code builds and runs locally
- [x] Feature / fix works as expected
- [x] No unintended changes
