### PR TITLE
feat: add simple first version button component

### DIFF
--- a/src/components/ui/buttons/index.tsx
+++ b/src/components/ui/buttons/index.tsx
@@ -1,0 +1,25 @@
+'use client';
+import React from 'react';
+
+interface StyledButtonProps {
+  children: React.ReactNode;
+  onClick?: () => void;
+
+  variant?: 'primary' | 'secondary';
+}
+
+export function StyledButton({ children, onClick, variant = 'primary' }: StyledButtonProps) {
+  const baseStyles =
+    'font-label text-xs md:text-base text-white py-1 px-5 rounded-sm transition duration-150 ease-in-out';
+
+  const primaryStyles = 'bg-secondary hover:bg-primary text-white';
+  const secondaryStyles = 'bg-gray-300 hover:bg-gray-400 text-gray-800'; //TODO: update colors
+
+  const variantStyles = variant === 'primary' ? primaryStyles : secondaryStyles;
+
+  return (
+    <button className={`${baseStyles} ${variantStyles}`} onClick={onClick}>
+      {children}
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary

Created very simple first version of button component using Noroff example. Secondary should be updated if we need it for a disabled button or other version. 

## Related Issue

Closes #60 

## Changes

- Created StyledButton in Button folder index.tsx
- Button has two version, primary and secondary (secondary is unfinished) 

## How to Test

1. git checkout feat/60-button-component
2. import StyledButton and use it as <StyledButton > Text <StyledButton /> 
3. Check if only changing text size is okay for responsiveness. 

## Checklist

- [ ] Code builds and runs locally
- [ ] Feature / fix works as expected
- [ ] No unintended changes
