### PR TITLE
feat: add contact us page

### DIFF
--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,22 +1,9 @@
-import Link from 'next/link';
+import ContactSection from '@/components/features/contact';
 
 export default function ContactPage() {
   return (
-    <main className="mx-auto w-full max-w-3xl px-6 py-10">
-      <h1 className="text-2xl font-semibold tracking-tight">Contact</h1>
-      <p className="text-foreground/70 mt-2 text-sm">Basic placeholder page to verify routing.</p>
-
-      <div className="mt-6 flex flex-wrap gap-4 text-sm">
-        <Link href="/" className="hover:underline">
-          Home
-        </Link>
-        <Link href="/about" className="hover:underline">
-          About
-        </Link>
-        <Link href="/checkout" className="hover:underline">
-          Checkout
-        </Link>
-      </div>
+    <main className="bg-primary-brown/40 flex-1 bg-[url('/images/MoodImage.jpg')] bg-cover bg-center bg-blend-darken">
+      <ContactSection />
     </main>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -40,7 +40,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${aboreto.variable} ${alegreyaSansSC.variable} ${zenKurenaido.variable} ${inter.variable} antialiased`}
+        className={`${aboreto.variable} ${alegreyaSansSC.variable} ${zenKurenaido.variable} ${inter.variable} flex min-h-screen flex-col antialiased`}
       >
         <Header />
         {children}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,10 +10,8 @@ interface HomeProps {
 export default async function Home({ searchParams }: HomeProps) {
   const { q, filter } = await searchParams;
   return (
-    <div className="min-h-screen">
-      <main className="mx-auto flex w-full max-w-3xl items-center py-10">
-        <SearchSection query={q || ''} filter={filter || 'All'} />
-      </main>
-    </div>
+    <main className="mx-auto flex w-full max-w-3xl flex-1 items-center py-10">
+      <SearchSection query={q || ''} filter={filter || 'All'} />
+    </main>
   );
 }

--- a/src/components/features/contact/contact-form.tsx
+++ b/src/components/features/contact/contact-form.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { ContactFormSchema } from '@/schemas/contact';
+import type { ContactFormData } from '@/schemas/contact';
+import { StyledButton } from '@/components/ui/buttons';
+
+function ContactForm() {
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors, isSubmitting, isValid },
+  } = useForm({
+    resolver: zodResolver(ContactFormSchema),
+    defaultValues: {
+      subject: '',
+      name: '',
+      email: '',
+      message: '',
+    },
+    delayError: 2000,
+    mode: 'onChange',
+  });
+
+  const onSubmit = (data: ContactFormData) => {
+    alert(`Hey, ${data.name}! Thank you for your message.`);
+    reset();
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit(onSubmit)}
+      className="bg-primary-brown flex w-full flex-col gap-4 px-4 py-6 md:px-8 md:py-10"
+    >
+      <div className="">
+        <label htmlFor="subject" className="sr-only">
+          Subject
+        </label>
+        <div className="font-label relative flex">
+          <input
+            id="subject"
+            type="text"
+            placeholder="Subject"
+            {...register('subject', { required: 'Subject is required' })}
+            aria-invalid={errors.subject ? 'true' : 'false'}
+            className="text-primary-brown w-full rounded-sm border bg-white px-1 py-1 text-sm placeholder-current md:text-base"
+          />
+        </div>
+        {errors.subject && (
+          <p role="alert" className="text-accent font-body mt-1 text-sm md:text-base">
+            {errors.subject.message}
+          </p>
+        )}
+      </div>
+      <div className="">
+        <label htmlFor="name" className="sr-only">
+          Name
+        </label>
+        <div className="font-label relative flex">
+          <input
+            id="name"
+            type="text"
+            autoComplete="name"
+            placeholder="Name"
+            {...register('name', { required: 'Name is required' })}
+            aria-invalid={errors.name ? 'true' : 'false'}
+            className="text-primary-brown w-full rounded-sm border bg-white px-1 py-1 text-sm placeholder-current md:text-base"
+          />
+        </div>
+        {errors.name && (
+          <p role="alert" className="text-accent font-body mt-1 text-sm md:text-base">
+            {errors.name.message}
+          </p>
+        )}
+      </div>
+      <div className="">
+        <label htmlFor="email" className="sr-only">
+          Email
+        </label>
+        <div className="font-label relative flex">
+          <input
+            id="email"
+            type="email"
+            autoComplete="email"
+            placeholder="Email"
+            {...register('email', { required: 'Email is required' })}
+            aria-invalid={errors.email ? 'true' : 'false'}
+            className="text-primary-brown w-full rounded-sm border bg-white px-1 py-1 text-sm placeholder-current md:text-base"
+          />
+        </div>
+        {errors.email && (
+          <p role="alert" className="text-accent font-body mt-1 text-sm md:text-base">
+            {errors.email.message}
+          </p>
+        )}
+      </div>
+      <div className="">
+        <label htmlFor="message" className="sr-only">
+          Message
+        </label>
+        <div className="font-label relative flex h-40">
+          <textarea
+            id="message"
+            placeholder="Message"
+            {...register('message', { required: 'Message is required' })}
+            aria-invalid={errors.message ? 'true' : 'false'}
+            className="text-primary-brown w-full rounded-sm border bg-white px-1 py-1 text-sm placeholder-current md:text-base"
+          />
+        </div>
+        {errors.message && (
+          <p role="alert" className="text-accent font-body mt-1 text-sm md:text-base">
+            {errors.message.message}
+          </p>
+        )}
+      </div>
+      <StyledButton disabled={!isValid || isSubmitting} variant={'primary'}>
+        Send
+      </StyledButton>
+    </form>
+  );
+}
+
+export default ContactForm;

--- a/src/components/features/contact/index.tsx
+++ b/src/components/features/contact/index.tsx
@@ -1,0 +1,12 @@
+import ContactForm from './contact-form';
+
+export default function ContactSection() {
+  return (
+    <section className="mx-auto flex max-w-[70%] flex-col items-center justify-center py-16 sm:max-w-75 md:max-w-lg">
+      <div className="container flex flex-col items-center justify-center">
+        <h2 className="font-hero text-accent mb-4 text-3xl tracking-wide">Contact Us</h2>
+        <ContactForm />
+      </div>
+    </section>
+  );
+}

--- a/src/components/features/products/search/search-section.tsx
+++ b/src/components/features/products/search/search-section.tsx
@@ -1,5 +1,5 @@
 import ProductsSearchFilter from '@/components/features/products/search/products-search-filter';
-import { ProductGrid } from '@/components/features/products/product-grid';
+import ProductGrid from '@/components/features/products/product-grid';
 import { getAllProducts } from '../services/product-service';
 import SearchForm from './search-form';
 import FilterDropdown from '@/components/features/products/search/filter-dropdown';

--- a/src/components/ui/buttons/index.tsx
+++ b/src/components/ui/buttons/index.tsx
@@ -4,21 +4,27 @@ import React from 'react';
 interface StyledButtonProps {
   children: React.ReactNode;
   onClick?: () => void;
-
+  disabled?: boolean;
   variant?: 'primary' | 'secondary';
 }
 
-export function StyledButton({ children, onClick, variant = 'primary' }: StyledButtonProps) {
+export function StyledButton({
+  children,
+  onClick,
+  disabled,
+  variant = 'primary',
+}: StyledButtonProps) {
   const baseStyles =
     'font-label text-xs md:text-base text-white py-1 px-5 rounded-sm transition duration-150 ease-in-out';
 
-  const primaryStyles = 'bg-secondary hover:bg-primary text-white';
-  const secondaryStyles = 'bg-gray-300 hover:bg-gray-400 text-gray-800'; //TODO: update colors
+  const primaryStyles =
+    'bg-secondary hover:bg-primary text-white disabled:bg-primary/60 disabled:text-gray-500 disabled:cursor-not-allowed';
+  const secondaryStyles = 'bg-gray-300 hover:bg-gray-400 text-gray-800 '; //TODO: update colors
 
   const variantStyles = variant === 'primary' ? primaryStyles : secondaryStyles;
 
   return (
-    <button className={`${baseStyles} ${variantStyles}`} onClick={onClick}>
+    <button className={`${baseStyles} ${variantStyles}`} onClick={onClick} disabled={disabled}>
       {children}
     </button>
   );

--- a/src/schemas/contact.ts
+++ b/src/schemas/contact.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+export const ContactFormSchema = z.object({
+  subject: z
+    .string()
+    .min(2, { message: 'Subject needs to be at least 2 characters long.' })
+    .max(100, { message: 'Subject cannot be longer than 100 characters.' }),
+  name: z
+    .string()
+    .min(2, { message: 'Name needs to be at least 2 characters long.' })
+    .max(100, { message: 'Name cannot be longer than 100 characters.' }),
+  email: z.string().email({ message: 'Please enter a valid email address.' }),
+  message: z
+    .string()
+    .min(10, { message: 'Message needs to be at least 10 characters long.' })
+    .max(500, { message: 'Message cannot be longer than 500 characters.' }),
+});
+
+export type ContactFormData = z.infer<typeof ContactFormSchema>;


### PR DESCRIPTION
### Created contact us Page

## Summary

Created a basic contact us page with a form with validation and user feedback. 

## Related Issue

Closes: #88 

---

### Known Limitations

- A successfully submitted form only triggers an alert. No modal for showing errors/messages exist yet. 
- No onError handler exist. 

## How to Test

1. git checkout feat/88-contact-us
2. navigate to /contact 
3. test responsiveness on mobile, tablet and desktop
4. test input and validation 
5. test submit 

---

### Known Issues

- Zero error handling exist, only validation feedback. 

### Follow-up tasks

- Create toast or modal for displaying error messages. 