### PR TITLE
feat: add checkout success page

### DIFF
--- a/src/app/checkout/page.tsx
+++ b/src/app/checkout/page.tsx
@@ -1,17 +1,22 @@
 'use client';
+import { useCartStore } from '@/store/cartStore';
 import { ShoppingCart } from '@/components/features/cart/cart';
 import { StyledButton } from '@/components/ui/buttons';
+import { useRouter } from 'next/navigation';
 
 export default function CheckoutPage() {
+  const router = useRouter();
   return (
     <main className="mx-auto w-full max-w-3xl flex-1 px-6 py-10">
       <h1 className="font-hero text-accent text-center text-[2rem]">Checkout</h1>
       <ShoppingCart mode="checkout" />
-      {/* Navigate to payment page */}
       <StyledButton
         variant={'primary'}
         onClick={() => {
-          document.location.href = '/cart';
+          const { items, setOrderSummary, clearCart } = useCartStore.getState();
+          setOrderSummary(items);
+          clearCart();
+          router.push('/checkout/success');
         }}
         className="mx-auto block"
       >

--- a/src/app/checkout/success/page.tsx
+++ b/src/app/checkout/success/page.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { useCartStore } from '@/store/cartStore';
+import { useRouter } from 'next/navigation';
+import { SuccessOverview } from '@/components/features/checkout/success';
+import SuccessCheckmark from '@/components/ui/success-checkmark';
+import { StyledButton } from '@/components/ui/buttons';
+import Link from 'next/link';
+
+export default function SuccessPage() {
+  const router = useRouter();
+  const orderSummary = useCartStore((state) => state.orderSummary);
+
+  if (orderSummary.length === 0) {
+    return (
+      <main className="...">
+        <p>
+          No order found. <Link href="/products">Continue shopping</Link>
+        </p>
+      </main>
+    );
+  }
+
+  return (
+    <main className="mx-auto flex w-full max-w-3xl flex-col items-center gap-2 px-4 py-10 sm:px-6">
+      <h1 className="font-hero text-heading-color text-2xl capitalize">Order confirmed</h1>
+      <SuccessCheckmark />
+      <h2 className="font-heading text-center text-base">Order summary</h2>
+      <p className="font-body text-center text-sm text-gray-600">
+        Thank you for your order! Your order has been successfully processed. You will receive an
+        email confirmation shortly. If you have any questions about your order, please contact our
+        support team.
+      </p>
+      <StyledButton
+        onClick={() => {
+          router.push('/');
+        }}
+      >
+        Continue Shopping
+      </StyledButton>
+      <SuccessOverview />
+      <StyledButton
+        onClick={() => {
+          router.push('/');
+        }}
+      >
+        Home
+      </StyledButton>
+    </main>
+  );
+}

--- a/src/components/features/checkout/success.tsx
+++ b/src/components/features/checkout/success.tsx
@@ -1,0 +1,56 @@
+'use client';
+import { useCartStore } from '@/store/cartStore';
+import Image from 'next/image';
+import Link from 'next/link';
+
+export function SuccessOverview() {
+  const purchasedItems = useCartStore((state) => state.orderSummary);
+
+  return (
+    <div className="mx-auto flex w-full max-w-3xl flex-col px-0 py-10 sm:px-6">
+      <div className="font-heading§ bg-secondary mb-4 grid w-full grid-cols-[minmax(0,1.8fr)_0.8fr_0.7fr_0.8fr] items-center rounded-xs px-2 text-[14px] text-white uppercase">
+        <div className="p-2">Product details</div>
+        <div className="p-2 text-right">Price</div>
+        <div className="p-2 text-right">Quantity</div>
+        <div className="p-2 text-right">Total</div>
+      </div>
+
+      <div className="font-body mx-auto flex w-full max-w-3xl flex-col">
+        {purchasedItems.map((line) => (
+          <div
+            key={line.id}
+            className="mb-4 grid grid-cols-[minmax(0,1.8fr)_0.8fr_0.7fr_0.8fr] items-center p-2"
+          >
+            <Link href={`/products/${line.id}`}>
+              <div className="xs:text-base flex items-center gap-1 text-xs">
+                <Image
+                  src={line.image.url}
+                  alt={line.image.alt}
+                  width={48}
+                  height={48}
+                  className="inline-block h-12 w-12"
+                />
+                {line.title}
+              </div>
+            </Link>
+            <div className="xs:text-base xs:p-2 p-0 text-right text-sm">
+              ${line.discountedPrice.toFixed(2)}
+            </div>
+            <div className="flex items-center justify-end gap-2 p-2 text-right">
+              {line.quantity}
+            </div>
+            <div className="xs:text-base p-2 text-right text-sm">
+              ${(line.quantity * line.discountedPrice).toFixed(2)}
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className="px-6 py-2 text-right text-lg font-semibold">
+        Total: $
+        {purchasedItems
+          .reduce((sum, line) => sum + line.quantity * line.discountedPrice, 0)
+          .toFixed(2)}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/success-checkmark.tsx
+++ b/src/components/ui/success-checkmark.tsx
@@ -1,0 +1,25 @@
+import { twMerge } from 'tailwind-merge';
+
+type LogoProps = {
+  className?: string;
+};
+
+export default function SuccessCheckmark({ className }: LogoProps) {
+  return (
+    <svg
+      className={twMerge('h-42.5 w-42.5 text-[#F9C67A]', className)}
+      viewBox="0 0 85 85"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle cx="42.5" cy="42.5" r="40.5" stroke="currentColor" strokeWidth="5" className="" />
+
+      <path
+        d="M77.6094 10.5397C59.5752 33.6728 48.5767 55.0547 37.874 76.3365C28.0465 63.3989 17.8269 53.1104 7.30957 41.7369L9.37207 38.2438C16.5107 43.0112 28.0198 52.0955 35.167 58.5338L35.3984 58.7418L35.5518 58.4713C45.9061 40.1727 57.8186 24.765 73.1455 8.49573L77.6094 10.5397Z"
+        stroke="black"
+        strokeWidth="0.5"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}

--- a/src/store/cartStore.ts
+++ b/src/store/cartStore.ts
@@ -6,6 +6,7 @@ export const useCartStore = create<CartStore>()(
   persist(
     (set) => ({
       items: [],
+      orderSummary: [],
       addItem: (product, quantity = 1) => {
         set((state) => {
           const existingItem = state.items.find((item) => item.id === product.id);
@@ -39,9 +40,8 @@ export const useCartStore = create<CartStore>()(
             .filter((item) => item.quantity > 0) as typeof state.items,
         }));
       },
-      clearCart: () => {
-        set({ items: [] });
-      },
+      clearCart: () => set({ items: [] }),
+      setOrderSummary: (items) => set({ orderSummary: items }),
     }),
     {
       name: 'cart-storage',

--- a/src/types/cart.ts
+++ b/src/types/cart.ts
@@ -6,8 +6,10 @@ export interface CartItem extends Product {
 
 export type CartStore = {
   items: CartItem[];
+  orderSummary: CartItem[];
   addItem: (product: Product, quantity?: number) => void;
   removeItem: (productId: string) => void;
   updateQuantity: (productId: string, quantity: number) => void;
   clearCart: () => void;
+  setOrderSummary: (items: CartItem[]) => void;
 };


### PR DESCRIPTION
### Created checkout success page

## Summary

Set up page layout and functionality for checkout success page. 

## Related Issue

Closes: #32 

---

### Known Limitations

There is currently no clearOrderSummary functionality. The orderSummary is cleared when a new checkout prosess is completed. 


## How to Test

1. checkout the branch
2. add a few items to the basket
3. click pay and checkout the success page 

---

